### PR TITLE
Add NPM command to generate new sub-package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "private": true,
   "scripts": {
+    "create": "node ./scripts/generate-sub-package",
     "bootstrap": "npm run clean && lerna bootstrap && lerna exec -- mkdir ./.git && npm run link",
     "build": "lerna run build",
     "clean": "run-p clean:*",
@@ -36,6 +37,7 @@
     "codecov": "^3.0.0",
     "eslint": "^4.7.2",
     "eslint-plugin-import": "^2.8.0",
+    "inquirer": "^5.1.0",
     "jest": "^21.2.1",
     "lerna": "^2.5.1",
     "np": "^2.18.2",

--- a/scripts/generate-sub-package.js
+++ b/scripts/generate-sub-package.js
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+/**
+ * This script generates new sub package with intial structure and files
+ */
+
+const fs = require('fs')
+const path = require('path')
+const shell = require('shelljs')
+const inquirer = require('inquirer')
+const packageType = ['reporter', 'service', 'runner']
+const questions = [
+    {
+        type: 'input',
+        name: 'packageName',
+        message: 'Provide sub package name:'
+    },
+    {
+        type: 'list',
+        name: 'packageType',
+        message: 'Select sub package type:',
+        choices: packageType,
+        default: 'reporter'
+    }
+]
+
+inquirer.prompt(questions).then(answers => {
+    const {packageName, packageType} = answers
+    const packagesDir = path.join(__dirname, '..', 'packages')
+    const fullPackageName = `wdio-${packageName}-${packageType}`
+
+    const mainPackageFolder = path.join(packagesDir, fullPackageName)
+    const mainPackageFolderFiles = [
+        {
+            name: '.npmignore',
+            content: 'src\ntests'
+        },
+        {
+            name: '.npmrc',
+            content: `message = "${fullPackageName}: bump version %s"`
+        },
+        {
+            name: 'package.json',
+            content: `{
+  "name": "${fullPackageName}",
+  "version": "0.0.0",
+  "description": "A WebdriverIO ${packageType} that <provide ${packageType} description>",
+  "author": "Christian Bromann <christian@saucelabs.com>",
+  "homepage": "https://github.com/webdriverio/webdriverio/packages/${fullPackageName}",
+  "license": "MIT",
+  "main": "./build/index",
+  "engines": {
+    "node": ">= 4.8.5"
+  },
+  "scripts": {
+    "build": "run-s clean compile",
+    "clean": "rm -rf ./build",
+    "compile": "babel src/ -d build/",
+    "postversion": "npm run build && git tag -d $(git tag -l)",
+    "test": "run-s test:*",
+    "test:eslint": "eslint src test",
+    "test:unit": "jest"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/webdriverio/webdriverio.git"
+  },
+  "keywords": [
+    "webdriver",
+    "wdio",
+    "wdio-${packageType}"
+  ],
+  "bugs": {
+    "url": "https://github.com/webdriverio/webdriverio/issues"
+  },
+  "dependencies": {
+  }
+}`
+        },
+        {
+            name: 'README.md',
+            content: `WebdriverIO ${packageName.toUpperCase()} ${packageType.charAt(0).toUpperCase()}${packageType.substr(1)}\n========================`
+        }
+    ]
+
+    const srcPackageFolder = path.join(mainPackageFolder, 'src')
+    const srcPackageFolderFiles = [
+        {
+            name: 'index.js',
+            content: 'export default {}'
+        }
+    ]
+
+    const testsPackageFolder = path.join(mainPackageFolder, 'tests')
+    const testsPackageFolderFiles = [
+        {
+            name: '.eslintrc',
+            content: `{
+  "env": {
+    "jest": true
+  }
+}`
+        },
+        {
+            name: 'example.test.js',
+            content: `describe('Unit test example', () => {
+    it('Test #1', () => {
+        expect(1).toBe(1)
+    })
+})`
+        }
+    ]
+
+    const existingPackages = fs.readdirSync(packagesDir)
+        .map(name => path.join(packagesDir, name))
+        .filter(source => fs.lstatSync(source).isDirectory())
+
+    const createFile = (file, content) => {
+        shell.touch(file)
+        shell.ShellString(content).to(file)
+    }
+
+    if (packageName === '') {
+        throw new Error('Package name can not be empty')
+    }
+
+    if (existingPackages.includes(mainPackageFolder)) {
+        throw new Error(`Package '${fullPackageName}' already exists. Please choose another name.`)
+    }
+
+    // create package structure
+    [mainPackageFolder, srcPackageFolder, testsPackageFolder].map(folder => shell.mkdir(folder))
+
+    // create main folder files
+    mainPackageFolderFiles.map(file => createFile(path.join(mainPackageFolder, file.name), file.content))
+
+    // create src folder files
+    srcPackageFolderFiles.map(file => createFile(path.join(srcPackageFolder, file.name), file.content))
+
+    // create tests folder files
+    testsPackageFolderFiles.map(file => createFile(path.join(testsPackageFolder, file.name), file.content))
+/* eslint-disable-next-line no-console */
+}).catch(err => console.error(err))


### PR DESCRIPTION
## Proposed changes
Relates to https://github.com/webdriverio/v5/issues/12

NPM command `npm run create` to generate new sub package with initial structure and files.

Uses [inquirer](https://github.com/SBoudrias/Inquirer.js) to provide simple CLI which asks the user for sub-package name and type.

Example of generated sub-package:
![screen shot 2018-03-22 at 12 26 12 pm](https://user-images.githubusercontent.com/7752864/37765187-3c73df8c-2dcc-11e8-8b65-f2b483fe5240.png)


[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/v5/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
