### PR TITLE
webdriverio: ported cookie commands

### DIFF
--- a/packages/webdriverio/src/commands/browser/deleteCookies.js
+++ b/packages/webdriverio/src/commands/browser/deleteCookies.js
@@ -1,12 +1,12 @@
-export default async function deleteCookies(names) {
+export default function deleteCookies(names) {
     const namesList = typeof names !== 'undefined' && !Array.isArray(names) ? [names] : names
 
     if (typeof namesList === 'undefined') {
-        return await this.deleteAllCookies()
+        return this.deleteAllCookies()
     }
 
     if (namesList.every(obj => typeof obj !== 'string')) {
-        throw new Error('Invalid input (see http://webdriver.io/api/cookie/deleteCookies.html for documentation.')
+        return Promise.reject(new Error('Invalid input (see http://webdriver.io/api/cookie/deleteCookies.html for documentation.'))
     }
 
     return Promise.all(namesList.map(name => this.deleteCookie(name)))

--- a/packages/webdriverio/src/commands/browser/deleteCookies.js
+++ b/packages/webdriverio/src/commands/browser/deleteCookies.js
@@ -1,0 +1,13 @@
+export default async function deleteCookies(names) {
+    const namesList = typeof names !== 'undefined' && !Array.isArray(names) ? [names] : names
+
+    if (typeof namesList === 'undefined') {
+        return await this.deleteAllCookies()
+    }
+
+    if (namesList.every(obj => typeof obj !== 'string')) {
+        throw new Error('Invalid input (see http://webdriver.io/api/cookie/deleteCookies.html for documentation.')
+    }
+
+    return Promise.all(namesList.map(name => this.deleteCookie(name)))
+}

--- a/packages/webdriverio/src/commands/browser/getCookies.js
+++ b/packages/webdriverio/src/commands/browser/getCookies.js
@@ -1,0 +1,15 @@
+export default async function getCookies(names) {
+    const namesList = typeof names !== 'undefined' && !Array.isArray(names) ? [names] : names
+
+    if (typeof namesList === 'undefined') {
+        return await this.getAllCookies()
+    }
+
+    if (namesList.every(obj => typeof obj !== 'string')) {
+        throw new Error('Invalid input (see http://webdriver.io/api/cookie/getCookies.html for documentation.')
+    }
+
+    const allCookies = await this.getAllCookies()
+
+    return allCookies.filter(cookie => namesList.includes(cookie.name));
+}

--- a/packages/webdriverio/src/commands/browser/getCookies.js
+++ b/packages/webdriverio/src/commands/browser/getCookies.js
@@ -2,7 +2,7 @@ export default async function getCookies(names) {
     const namesList = typeof names !== 'undefined' && !Array.isArray(names) ? [names] : names
 
     if (typeof namesList === 'undefined') {
-        return await this.getAllCookies()
+        return this.getAllCookies()
     }
 
     if (namesList.every(obj => typeof obj !== 'string')) {

--- a/packages/webdriverio/src/commands/browser/setCookies.js
+++ b/packages/webdriverio/src/commands/browser/setCookies.js
@@ -1,0 +1,9 @@
+export default async function setCookies(cookieObjs) {
+    const cookieObjsList = !Array.isArray(cookieObjs) ? [cookieObjs] : cookieObjs;
+
+    if (cookieObjsList.some(obj => !(obj instanceof Object))) {
+        throw new Error('Invalid input (see http://webdriver.io/api/cookie/setCookies.html for documentation.')
+    }
+
+    return Promise.all(cookieObjsList.map(cookieObj => this.addCookie(cookieObj)))
+}

--- a/packages/webdriverio/tests/__mocks__/request.js
+++ b/packages/webdriverio/tests/__mocks__/request.js
@@ -67,6 +67,13 @@ export default jest.fn().mockImplementation((params, cb) => {
             { [ELEMENT_KEY]: 'some-elem-789' },
         ]
         break;
+    case `/wd/hub/session/${sessionId}/cookie`:
+        value = [
+            { name: 'cookie1', value: 'dummy-value-1' },
+            { name: 'cookie2', value: 'dummy-value-2' },
+            { name: 'cookie3', value: 'dummy-value-3' },
+        ]
+        break;
     }
 
     let response = { value }

--- a/packages/webdriverio/tests/commands/browser/deleteCookies.test.js
+++ b/packages/webdriverio/tests/commands/browser/deleteCookies.test.js
@@ -1,0 +1,56 @@
+import request from 'request'
+import { remote } from '../../../src'
+
+describe('deleteCookies', () => {
+    let browser
+
+    beforeAll(async () => {
+        browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foobar'
+            }
+        })
+    })
+
+    it('should delete all cookies', async () => {
+        await browser.deleteCookies()
+
+        expect(request.mock.calls[1][0].method).toBe('DELETE')
+        expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/cookie')
+    })
+
+    it('should support passing a string', async () => {
+        await browser.deleteCookies('cookie1')
+
+        expect(request.mock.calls[0][0].method).toBe('DELETE')
+        expect(request.mock.calls[0][0].uri.path).toBe('/wd/hub/session/foobar-123/cookie/cookie1')
+    })
+
+    it('should support passing a array with a string', async () => {
+        await browser.deleteCookies(['cookie1'])
+
+        expect(request.mock.calls[0][0].method).toBe('DELETE')
+        expect(request.mock.calls[0][0].uri.path).toBe('/wd/hub/session/foobar-123/cookie/cookie1')
+    })
+
+    it('should delete cookies that match by name', async () => {
+        const cookieNames = ['cookie1', 'cookie2', 'cookie3']
+        await browser.deleteCookies(cookieNames)
+
+        cookieNames.forEach((name, i) => {
+            expect(request.mock.calls[i][0].method).toBe('DELETE')
+            expect(request.mock.calls[i][0].uri.path).toBe(`/wd/hub/session/foobar-123/cookie/${name}`)
+        })
+    })
+
+    it('should throw error if invalid arguments are passed', async () => {
+        await expect(browser.deleteCookies([2]))
+            .rejects
+            .toEqual(new Error('Invalid input (see http://webdriver.io/api/cookie/deleteCookies.html for documentation.'))
+    })
+
+    afterEach(() => {
+        request.mockClear()
+    })
+})

--- a/packages/webdriverio/tests/commands/browser/getCookies.test.js
+++ b/packages/webdriverio/tests/commands/browser/getCookies.test.js
@@ -1,0 +1,65 @@
+import request from 'request'
+import { remote } from '../../../src'
+
+describe('getCookies', () => {
+    let browser
+
+    beforeAll(async () => {
+        browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foobar'
+            }
+        })
+    })
+
+    it('should return all cookies', async () => {
+        const cookies = await browser.getCookies()
+
+        expect(request.mock.calls[1][0].method).toBe('GET')
+        expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/cookie')
+        expect(cookies).toEqual([
+            { name: 'cookie1', value: 'dummy-value-1' },
+            { name: 'cookie2', value: 'dummy-value-2' },
+            { name: 'cookie3', value: 'dummy-value-3' },
+        ]);
+    })
+
+    it('should support passing a string', async () => {
+        const cookies = await browser.getCookies('cookie1')
+
+        expect(request.mock.calls[0][0].method).toBe('GET')
+        expect(request.mock.calls[0][0].uri.path).toBe('/wd/hub/session/foobar-123/cookie')
+        expect(cookies).toEqual([{ name: 'cookie1', value: 'dummy-value-1' }]);
+    })
+
+    it('should support passing a array with strings', async () => {
+        const cookies = await browser.getCookies(['cookie1'])
+
+        expect(request.mock.calls[0][0].method).toBe('GET')
+        expect(request.mock.calls[0][0].uri.path).toBe('/wd/hub/session/foobar-123/cookie')
+        expect(cookies).toEqual([{ name: 'cookie1', value: 'dummy-value-1' }]);
+    })
+
+    it('should get all cookies and filter out cookies that match by name', async () => {
+        const cookieNames = ['cookie1', 'doesn-not-exist', 'cookie3']
+        const cookies = await browser.getCookies(cookieNames)
+
+        expect(request.mock.calls[0][0].method).toBe('GET')
+        expect(request.mock.calls[0][0].uri.path).toBe(`/wd/hub/session/foobar-123/cookie`)
+        expect(cookies).toEqual([
+            { name: 'cookie1', value: 'dummy-value-1' },
+            { name: 'cookie3', value: 'dummy-value-3' },
+        ]);
+    })
+
+    it('should throw error if invalid arguments are passed', async () => {
+        await expect(browser.getCookies([2]))
+            .rejects
+            .toEqual(new Error('Invalid input (see http://webdriver.io/api/cookie/getCookies.html for documentation.'))
+    })
+
+    afterEach(() => {
+        request.mockClear()
+    })
+})

--- a/packages/webdriverio/tests/commands/browser/setCookies.test.js
+++ b/packages/webdriverio/tests/commands/browser/setCookies.test.js
@@ -1,0 +1,69 @@
+import request from 'request'
+import { remote } from '../../../src'
+
+describe('setCookies', () => {
+    let browser
+
+    beforeAll(async () => {
+        browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foobar'
+            }
+        })
+    })
+
+    it('should output the expected format', async () => {
+        await browser.setCookies([{ name: 'cookie1', value: 'dummy-value-1' }])
+        expect(request.mock.calls.length).toBe(2)
+        expect(request.mock.calls[1][0].method).toBe('POST')
+        expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/cookie')
+        expect(request.mock.calls[1][0].body).toEqual({ 'cookie': { name: 'cookie1', value: 'dummy-value-1' } })
+    })
+
+    it('should support passing an object', async () => {
+        await browser.setCookies({ name: 'cookie1', value: 'dummy-value-1' })
+        expect(request.mock.calls.length).toBe(1)
+        expect(request.mock.calls[0][0].method).toBe('POST')
+        expect(request.mock.calls[0][0].uri.path).toBe('/wd/hub/session/foobar-123/cookie')
+        expect(request.mock.calls[0][0].body).toEqual({ 'cookie': { name: 'cookie1', value: 'dummy-value-1' } })
+    })
+
+    it('can be called multiple times', async () => {
+        await browser.setCookies({ name: 'cookie1', value: 'dummy-value-1' })
+        await browser.setCookies({ name: 'cookie2', value: 'dummy-value-1' })
+        expect(request.mock.calls.length).toBe(2)
+        expect(request.mock.calls[0][0].method).toBe('POST')
+        expect(request.mock.calls[0][0].uri.path).toBe('/wd/hub/session/foobar-123/cookie')
+        expect(request.mock.calls[0][0].body).toEqual({ 'cookie': { name: 'cookie1', value: 'dummy-value-1' } })
+        expect(request.mock.calls[1][0].method).toBe('POST')
+        expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/cookie')
+        expect(request.mock.calls[1][0].body).toEqual({ 'cookie': { name: 'cookie2', value: 'dummy-value-1' } })
+    })
+
+    it('should work with multiple objects passed', async () => {
+        const cookies = [
+            { name: 'cookie1', value: 'dummy-value-1' },
+            { name: 'cookie2', value: 'dummy-value-2' },
+            { name: 'cookie3', value: 'dummy-value-3' }
+        ]
+
+        await browser.setCookies(cookies)
+
+        cookies.forEach((cookie, i) => {
+            expect(request.mock.calls[i][0].method).toBe('POST')
+            expect(request.mock.calls[i][0].uri.path).toBe('/wd/hub/session/foobar-123/cookie')
+            expect(request.mock.calls[i][0].body).toEqual({ 'cookie': cookie })
+        })
+    })
+
+    it('should throw error if invalid arguments are passed', async () => {
+        await expect(browser.setCookies([2]))
+            .rejects
+            .toEqual(new Error('Invalid input (see http://webdriver.io/api/cookie/setCookies.html for documentation.'))
+    })
+
+    afterEach(() => {
+        request.mockClear()
+    })
+})


### PR DESCRIPTION
## Proposed changes

Ported over the cookie command methods and changed them from being able to pass a single cookie at a time to being able to pass multiple cookies to be handled.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x ] I have read the [CONTRIBUTING](https://github.com/webdriverio/v5/blob/master/CONTRIBUTING.md) doc
- [x ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Using getCookies I have chosen not to use getNamedCookie but instead query all cookies using getAllCookies to then filter the list it returns.

### Reviewers: @webdriverio/technical-committee @christian-bromann 
