### PR TITLE
Port state commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ We are trying to put up a proper roadmap for the beta release. Until then please
 - [wdio-dot-reporter](https://github.com/webdriverio/v5/tree/master/packages/wdio-dot-reporter) - A WebdriverIO plugin to report in dot style
 - [wdio-spec-reporter](https://github.com/webdriverio/v5/tree/master/packages/wdio-spec-reporter) - A WebdriverIO plugin to report in spec style
 - [wdio-sumologic-reporter](https://github.com/webdriverio/v5/tree/master/packages/wdio-sumologic-reporter) - A WebdriverIO reporter that sends test results to Sumologic for data analyses
-- [wdio-xml-reporter](https://github.com/webdriverio/v5/tree/master/packages/wdio-xml-reporter) - A WebdriverIO reporter that creates test results in XML format
+- [wdio-junit-reporter](https://github.com/webdriverio/v5/tree/master/packages/wdio-junit-reporter) - A WebdriverIO reporter that creates test results in XML format
 
 ### Services
 
@@ -73,3 +73,8 @@ We are trying to put up a proper roadmap for the beta release. Until then please
 - [wdio-firefox-profile-service](https://github.com/webdriverio/v5/tree/master/packages/wdio-firefox-profile-service) - WebdriverIO service that lets you define your Firefox profile in your wdio.conf.js
 - [wdio-sauce-service](https://github.com/webdriverio/v5/tree/master/packages/wdio-sauce-service) - WebdriverIO service that provides a better integration into SauceLabs
 - [wdio-testingbot-service](https://github.com/webdriverio/v5/tree/master/packages/wdio-testingbot-service) - WebdriverIO service that provides a better integration into TestingBot
+
+### Runner
+
+- [wdio-local-runner](https://github.com/webdriverio/v5/tree/master/packages/wdio-local-runner) - A WebdriverIO runner to run tests locally
+- [wdio-firefox-profile-service](https://github.com/webdriverio/v5/tree/master/packages/wdio-firefox-profile-service) - A WebdriverIO plugin that allows you to run tests on AWS

--- a/packages/webdriverio/src/commands/element/isDisplayedInViewport.js
+++ b/packages/webdriverio/src/commands/element/isDisplayedInViewport.js
@@ -1,0 +1,45 @@
+
+/**
+ *
+ * Return true if the selected DOM-element found by given selector is visible and within the viewport.
+ *
+ * <example>
+    :index.html
+    <div id="notDisplayed" style="display: none"></div>
+    <div id="notVisible" style="visibility: hidden"></div>
+    <div id="notInViewport" style="position:absolute; left: 9999999"></div>
+    <div id="zeroOpacity" style="opacity: 0"></div>
+    :isVisibleWithinViewport.js
+    :isVisible.js
+    it('should detect if an element is visible', function () {
+        var isVisibleWithinViewport = browser.isVisibleWithinViewport('#notDisplayed');
+        console.log(isVisibleWithinViewport); // outputs: false
+        isVisibleWithinViewport = browser.isVisibleWithinViewport('#notVisible');
+        console.log(isVisibleWithinViewport); // outputs: false
+        isVisibleWithinViewport = browser.isVisibleWithinViewport('#notExisting');
+        console.log(isVisibleWithinViewport); // outputs: false
+        isVisibleWithinViewport = browser.isVisibleWithinViewport('#notInViewport');
+        console.log(isVisibleWithinViewport); // outputs: false
+        isVisibleWithinViewport = browser.isVisibleWithinViewport('#zeroOpacity');
+        console.log(isVisibleWithinViewport); // outputs: false
+    });
+ * </example>
+ *
+ * @alias browser.isVisibleWithinViewport
+ * @param   {String}             selector  DOM-element
+ * @return {Boolean|Boolean[]}            true if element(s)* [is|are] visible
+ * @uses protocol/selectorExecute, protocol/timeoutsAsyncScript
+ * @type state
+ *
+ */
+
+import { ELEMENT_KEY } from '../../constants'
+import { getBrowserObject } from '../../utils'
+import isDisplayedInViewportScript from '../../scripts/isDisplayedInViewport'
+
+export default function isDisplayedInViewport () {
+    return getBrowserObject(this).execute(isDisplayedInViewportScript, {
+        [ELEMENT_KEY]: this.elementId, // w3c compatible
+        ELEMENT: this.elementId // jsonwp compatible
+    })
+}

--- a/packages/webdriverio/src/commands/element/isDisplayedInViewport.js
+++ b/packages/webdriverio/src/commands/element/isDisplayedInViewport.js
@@ -12,7 +12,7 @@
     :isVisibleWithinViewport.js
     :isVisible.js
     it('should detect if an element is visible', function () {
-        var isVisibleWithinViewport = browser.isVisibleWithinViewport('#notDisplayed');
+        let isVisibleWithinViewport = browser.isVisibleWithinViewport('#notDisplayed');
         console.log(isVisibleWithinViewport); // outputs: false
         isVisibleWithinViewport = browser.isVisibleWithinViewport('#notVisible');
         console.log(isVisibleWithinViewport); // outputs: false

--- a/packages/webdriverio/src/commands/element/isExisting.js
+++ b/packages/webdriverio/src/commands/element/isExisting.js
@@ -14,15 +14,15 @@
         let elem = $('#someRandomNonExistingElement')
         let isExisting = elem.isExisting()
         console.log(isExisting); // outputs: false
-        
+
         elem = $('#notDisplayed')
         isExisting = elem.isExisting()
         console.log(isExisting); // outputs: true
-        
+
         elem = $('#notVisible')
         isExisting = elem.isExisting()
         console.log(isExisting); // outputs: true
-        
+
         elem = $('#notInViewport')
         isExisting = elem.isExisting()
         console.log(isExisting); // outputs: true
@@ -41,8 +41,6 @@
  *
  */
 
-let isExisting = function () {
+export default function isExisting () {
     return this.parent.$$(this.selector).then((res) => res.length > 0)
 }
-
-export default isExisting

--- a/packages/webdriverio/src/commands/element/isFocused.js
+++ b/packages/webdriverio/src/commands/element/isFocused.js
@@ -1,0 +1,36 @@
+/**
+ *
+ * Return true or false if the selected DOM-element currently has focus. If the selector matches
+ * multiple elements, it will return true if one of the elements has focus.
+ *
+ * <example>
+    :index.html
+    <input name="login" autofocus="" />
+    :hasFocus.js
+    it('should detect the focus of an element', function () {
+        browser.url('/');
+        var loginInput = $('[name="login"]');
+        console.log(loginInput.hasFocus()); // outputs: false
+        loginInput.click();
+        console.log(loginInput.hasFocus()); // outputs: true
+    })
+ * </example>
+ *
+ * @alias browser.isFocused
+ * @return {Boolean}         true if one of the matching elements has focus
+ *
+ * @uses protocol/execute
+ * @type state
+ *
+ */
+
+import { ELEMENT_KEY } from '../../constants'
+import { getBrowserObject } from '../../utils'
+import isFocusedScript from '../../scripts/isFocused'
+
+export default function isFocused () {
+    return getBrowserObject(this).execute(isFocusedScript, {
+        [ELEMENT_KEY]: this.elementId, // w3c compatible
+        ELEMENT: this.elementId // jsonwp compatible
+    })
+}

--- a/packages/webdriverio/src/commands/element/isFocused.js
+++ b/packages/webdriverio/src/commands/element/isFocused.js
@@ -9,7 +9,7 @@
     :hasFocus.js
     it('should detect the focus of an element', function () {
         browser.url('/');
-        var loginInput = $('[name="login"]');
+        const loginInput = $('[name="login"]');
         console.log(loginInput.hasFocus()); // outputs: false
         loginInput.click();
         console.log(loginInput.hasFocus()); // outputs: true

--- a/packages/webdriverio/src/scripts/.eslintrc.js
+++ b/packages/webdriverio/src/scripts/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  env: {
+    browser: true
+  }
+}

--- a/packages/webdriverio/src/scripts/isDisplayedInViewport.js
+++ b/packages/webdriverio/src/scripts/isDisplayedInViewport.js
@@ -1,12 +1,8 @@
-
 /**
  * check if element is visible and within the viewport
- *
- * @param {String}  elements  DOM elements to check against
- *
- * @see  waitForVisible
+ * @param  {HTMLElement} elem  element to check
+ * @return {Boolean}           true if element is within viewport
  */
-
 export default function isDisplayedInViewport (elem) {
     const dde = document.documentElement
 

--- a/packages/webdriverio/src/scripts/isDisplayedInViewport.js
+++ b/packages/webdriverio/src/scripts/isDisplayedInViewport.js
@@ -1,0 +1,35 @@
+
+/**
+ * check if element is visible and within the viewport
+ *
+ * @param {String}  elements  DOM elements to check against
+ *
+ * @see  waitForVisible
+ */
+
+export default function isDisplayedInViewport (elem) {
+    const dde = document.documentElement
+
+    let isWithinViewport = true
+    while (elem.parentNode && elem.parentNode.getBoundingClientRect) {
+        const elemDimension = elem.getBoundingClientRect()
+        const elemComputedStyle = window.getComputedStyle(elem)
+        const viewportDimension = {
+            width: dde.clientWidth,
+            height: dde.clientHeight
+        }
+
+        isWithinViewport = isWithinViewport &&
+                           (elemComputedStyle.display !== 'none' &&
+                            elemComputedStyle.visibility === 'visible' &&
+                            parseFloat(elemComputedStyle.opacity, 10) > 0 &&
+                            elemDimension.bottom > 0 &&
+                            elemDimension.right > 0 &&
+                            elemDimension.top < viewportDimension.height &&
+                            elemDimension.left < viewportDimension.width)
+
+        elem = elem.parentNode
+    }
+
+    return isWithinViewport
+}

--- a/packages/webdriverio/src/scripts/isFocused.js
+++ b/packages/webdriverio/src/scripts/isFocused.js
@@ -1,0 +1,8 @@
+/**
+ * checks if given element is focused
+ * @param  {HTMLElement} elem  element to check
+ * @return {Boolean}           true if element is focused
+ */
+export default function (elem) {
+    return elem === document.activeElement
+}

--- a/packages/webdriverio/src/scripts/newWindow.js
+++ b/packages/webdriverio/src/scripts/newWindow.js
@@ -1,5 +1,3 @@
-
-
 /**
  * opens new window via window.open
  * @param  {String} url            The URL to be loaded in the newly opened window.
@@ -8,8 +6,6 @@
  *
  * @see  https://developer.mozilla.org/en-US/docs/Web/API/Window.open
  */
-
-/* global window */
 export default function newWindow (url, windowName = 'new window', windowFeatures = '') {
     window.open(url, windowName, windowFeatures)
 }

--- a/packages/webdriverio/src/utils.js
+++ b/packages/webdriverio/src/utils.js
@@ -212,3 +212,13 @@ export function mobileDetector (caps) {
 
     return { isMobile, isIOS, isAndroid }
 }
+
+/**
+ * get browser object from element
+ */
+export function getBrowserObject (elem) {
+    if (elem.parent) {
+        return elem.parent
+    }
+    return elem
+}

--- a/packages/webdriverio/src/utils.js
+++ b/packages/webdriverio/src/utils.js
@@ -214,11 +214,8 @@ export function mobileDetector (caps) {
 }
 
 /**
- * get browser object from element
+ * traverse up the scope chain until browser element was reached
  */
 export function getBrowserObject (elem) {
-    if (elem.parent) {
-        return elem.parent
-    }
-    return elem
+    return elem.parent ? getBrowserObject(elem.parent) : elem
 }

--- a/packages/webdriverio/tests/commands/element/isDisplayedInViewport.test.js
+++ b/packages/webdriverio/tests/commands/element/isDisplayedInViewport.test.js
@@ -1,0 +1,30 @@
+import request from 'request'
+import { remote } from '../../../src'
+
+describe('isDisplayedInViewport test', () => {
+    let browser
+    let elem
+
+    beforeAll(async () => {
+        browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foobar'
+            }
+        })
+        elem = await browser.$('#foo')
+    })
+
+    it('should allow to check if element is displayed', async () => {
+        await elem.isDisplayedInViewport()
+        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/execute/sync')
+        expect(request.mock.calls[2][0].body.args[0]).toEqual({
+            'element-6066-11e4-a52e-4f735466cecf': 'some-elem-123',
+            ELEMENT: 'some-elem-123'
+        });
+    })
+
+    afterEach(() => {
+        request.mockClear()
+    })
+})

--- a/packages/webdriverio/tests/commands/element/isFocused.test.js
+++ b/packages/webdriverio/tests/commands/element/isFocused.test.js
@@ -1,0 +1,30 @@
+import request from 'request'
+import { remote } from '../../../src'
+
+describe('isFocused test', () => {
+    let browser
+    let elem
+
+    beforeAll(async () => {
+        browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foobar'
+            }
+        })
+        elem = await browser.$('#foo')
+    })
+
+    it('should allow to check if element is displayed', async () => {
+        await elem.isFocused()
+        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/execute/sync')
+        expect(request.mock.calls[2][0].body.args[0]).toEqual({
+            'element-6066-11e4-a52e-4f735466cecf': 'some-elem-123',
+            ELEMENT: 'some-elem-123'
+        });
+    })
+
+    afterEach(() => {
+        request.mockClear()
+    })
+})

--- a/packages/webdriverio/tests/scripts/isDisplayedInViewport.test.js
+++ b/packages/webdriverio/tests/scripts/isDisplayedInViewport.test.js
@@ -1,0 +1,78 @@
+/**
+ * @jest-environment node
+ */
+
+import isDisplayedInViewport from '../../src/scripts/isDisplayedInViewport'
+
+describe('isDisplayedInViewport script', () => {
+    it('should detect if in viewport correctly', () => {
+        global.document = {
+            documentElement: {
+                clientWidth: 800,
+                clientHeight: 600
+            }
+        }
+        global.window = {
+            getComputedStyle: jest.fn().mockReturnValue({
+                display: 'inline-block',
+                visibility: 'visible',
+                opacity: .8
+            })
+        }
+        const elemMock = {
+            getBoundingClientRect: () => ({
+                bottom: 55,
+                right: 22,
+                top: 33,
+                left: 555
+            }),
+            parentNode: {
+                getBoundingClientRect: () => ({
+                    bottom: 55,
+                    right: 22,
+                    top: 33,
+                    left: 555
+                })
+            }
+        }
+
+        expect(isDisplayedInViewport(elemMock)).toBe(true)
+    })
+
+    it('should detect if in viewport correctly', () => {
+        global.document = {
+            documentElement: {
+                clientWidth: 800,
+                clientHeight: 600
+            }
+        }
+        global.window = {
+            getComputedStyle: jest.fn().mockReturnValue({
+                display: 'inline-block',
+                visibility: 'visible',
+                opacity: .8
+            })
+        }
+        const elemMock = {
+            getBoundingClientRect: () => ({
+                bottom: 55,
+                right: 22,
+                top: 33,
+                left: 555
+            }),
+            parentNode: {
+                getBoundingClientRect: () => ({
+                    bottom: 55,
+                    right: 2112,
+                    top: 33,
+                    left: 855
+                }),
+                parentNode: {
+                    getBoundingClientRect: () => {}
+                }
+            }
+        }
+
+        expect(isDisplayedInViewport(elemMock)).toBe(false)
+    })
+})

--- a/packages/webdriverio/tests/scripts/isFocused.test.js
+++ b/packages/webdriverio/tests/scripts/isFocused.test.js
@@ -1,0 +1,9 @@
+/* global document */
+
+import isFocused from '../../src/scripts/isFocused'
+
+describe('isFocused script', () => {
+    it('should check if elem is active', () => {
+        expect(isFocused(document.activeElement)).toEqual(true)
+    })
+})

--- a/packages/webdriverio/tests/scripts/newWindow.test.js
+++ b/packages/webdriverio/tests/scripts/newWindow.test.js
@@ -1,0 +1,11 @@
+/* global window */
+
+import newWindow from '../../src/scripts/newWindow'
+
+describe('newWindow script', () => {
+    it('should check if elem is active', () => {
+        window.open = jest.fn()
+        newWindow('foo', 'bar', 'loo')
+        expect(window.open.mock.calls).toHaveLength(1)
+    })
+})

--- a/packages/webdriverio/tests/scripts/newWindow.test.js
+++ b/packages/webdriverio/tests/scripts/newWindow.test.js
@@ -7,5 +7,6 @@ describe('newWindow script', () => {
         window.open = jest.fn()
         newWindow('foo', 'bar', 'loo')
         expect(window.open.mock.calls).toHaveLength(1)
+        expect(window.open.mock.calls[0]).toEqual(['foo', 'bar', 'loo'])
     })
 })

--- a/packages/webdriverio/tests/utils.test.js
+++ b/packages/webdriverio/tests/utils.test.js
@@ -1,4 +1,4 @@
-import { findStrategy, getElementFromResponse, mobileDetector } from '../src/utils'
+import { findStrategy, getElementFromResponse, mobileDetector, getBrowserObject } from '../src/utils'
 
 describe('utils', () => {
     describe('selector strategies helper', () => {
@@ -323,6 +323,20 @@ describe('utils', () => {
             expect(isMobile).toEqual(true)
             expect(isIOS).toEqual(false)
             expect(isAndroid).toEqual(true)
+        })
+    })
+
+    describe('getBrowserObject', () => {
+        it('should traverse up', () => {
+            expect(getBrowserObject({
+                parent: {
+                    parent: {
+                        parent: {
+                            foo: 'bar'
+                        }
+                    }
+                }
+            })).toEqual({ foo: 'bar' })
         })
     })
 })


### PR DESCRIPTION
## The task

Port the following state commands:

- [x] hasFocus (to be renamed to `isFocused`)
- [x] isEnabled
- [x] isExisting
- [x] isSelected
- [x] isVisible
- [x] isVisibleWithinViewport

Acceptance criteria:

- [x] unit test

to the element scope. Add unit tests (similar to [these](https://github.com/webdriverio/v5/tree/master/packages/webdriverio/tests/commands/element)) to ensure the right requests are send to the browser driver.