### PR TITLE
Port over getHTML

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     },
     "coveragePathIgnorePatterns": [
       "/node_modules/",
-      "/webdriverio/src/scripts/newWindow.js"
+      "/packages/webdriverio/src/scripts"
     ]
   }
 }

--- a/packages/webdriverio/src/commands/element/getHTML.js
+++ b/packages/webdriverio/src/commands/element/getHTML.js
@@ -1,0 +1,40 @@
+/**
+ *
+ * Get source code of specified DOM element by selector.
+ *
+ * <example>
+    :index.html
+    <div id="test">
+        <span>Lorem ipsum dolor amet</span>
+    </div>
+    :getHTML.js
+    it('should get html for certain elements', function () {
+        var outerHTML = browser.getHTML('#test');
+        console.log(outerHTML);
+        // outputs:
+        // "<div id="test"><span>Lorem ipsum dolor amet</span></div>"
+        var innerHTML = browser.getHTML('#test', false);
+        console.log(innerHTML);
+        // outputs:
+        // "<span>Lorem ipsum dolor amet</span>"
+    });
+ * </example>
+ *
+ * @alias browser.getHTML
+ * @param {String}   selector           element to get the current DOM structure from
+ * @param {Boolean=} includeSelectorTag if true it includes the selector element tag (default: true)
+ * @uses action/selectorExecute
+ * @type property
+ *
+ */
+
+import { ELEMENT_KEY } from '../../constants'
+import { getBrowserObject } from '../../utils'
+import getHTMLScript from '../../scripts/getHTML'
+
+export default function getHTML (includeSelectorTag = true) {
+    return getBrowserObject(this).execute(getHTMLScript, {
+        [ELEMENT_KEY]: this.elementId, // w3c compatible
+        ELEMENT: this.elementId // jsonwp compatible
+    }, includeSelectorTag)
+}

--- a/packages/webdriverio/src/scripts/getHTML.js
+++ b/packages/webdriverio/src/scripts/getHTML.js
@@ -1,0 +1,12 @@
+
+/**
+ * get HTML of selector element
+ *
+ * @param  {String}  selector            element to get HTML from
+ * @param  {Boolean} includeSelectorTag  if true, selector tag gets included (uses outerHTML)
+ * @return {String}                      html source
+ */
+
+export default function getHTML (element, includeSelectorTag) {
+    return element[includeSelectorTag ? 'outerHTML' : 'innerHTML']
+}

--- a/packages/webdriverio/tests/__mocks__/request.js
+++ b/packages/webdriverio/tests/__mocks__/request.js
@@ -72,7 +72,7 @@ const requestMock = jest.fn().mockImplementation((params, cb) => {
     case `/wd/hub/session/${sessionId}/execute/sync`: {
         const script = Function(params.body.script)
         const args = params.body.args.map(arg => arg.ELEMENT || arg[ELEMENT_KEY] || arg)
-        value = script.apply(this, args)
+        value = script.apply(this, args) || {}
         break
     } case `/wd/hub/session/${sessionId}/element/some-elem-123/elements`:
         value = [

--- a/packages/webdriverio/tests/__mocks__/request.js
+++ b/packages/webdriverio/tests/__mocks__/request.js
@@ -30,17 +30,17 @@ const requestMock = jest.fn().mockImplementation((params, cb) => {
             delete value.capabilities
         }
 
-        break;
+        break
     case `/wd/hub/session/${sessionId}/element`:
         value = {
             [ELEMENT_KEY]: genericElementId
         }
-        break;
+        break
     case `/wd/hub/session/${sessionId}/element/some-elem-123/element`:
         value = {
             [ELEMENT_KEY]: genericSubElementId
         }
-        break;
+        break
     case `/wd/hub/session/${sessionId}/element/${genericElementId}/rect`:
         value = {
             x: 15,
@@ -48,49 +48,55 @@ const requestMock = jest.fn().mockImplementation((params, cb) => {
             height: 30,
             width: 50
         }
-        break;
+        break
     case `/wd/hub/session/${sessionId}/element/${genericElementId}/size`:
         value = {
             height: 30,
             width: 50
         }
-        break;
+        break
     case `/wd/hub/session/${sessionId}/element/${genericElementId}/location`:
         value = {
             x: 15,
             y: 20
         }
-        break;
+        break
     case `/wd/hub/session/${sessionId}/elements`:
         value = [
             { [ELEMENT_KEY]: genericElementId },
             { [ELEMENT_KEY]: 'some-elem-456' },
             { [ELEMENT_KEY]: 'some-elem-789' },
         ]
-        break;
-    case `/wd/hub/session/${sessionId}/element/some-elem-123/elements`:
+        break
+    case `/wd/hub/session/${sessionId}/execute`:
+    case `/wd/hub/session/${sessionId}/execute/sync`: {
+        const script = Function(params.body.script)
+        const args = params.body.args.map(arg => arg.ELEMENT || arg[ELEMENT_KEY] || arg)
+        value = script.apply(this, args)
+        break
+    } case `/wd/hub/session/${sessionId}/element/some-elem-123/elements`:
         value = [
             { [ELEMENT_KEY]: genericSubElementId },
             { [ELEMENT_KEY]: 'some-elem-456' },
             { [ELEMENT_KEY]: 'some-elem-789' },
         ]
-        break;
+        break
     case `/wd/hub/session/${sessionId}/cookie`:
         value = [
             { name: 'cookie1', value: 'dummy-value-1' },
             { name: 'cookie2', value: 'dummy-value-2' },
             { name: 'cookie3', value: 'dummy-value-3' },
         ]
-        break;
+        break
     case `/wd/hub/session/${sessionId}/window/handles`:
         value = ['window-handle-1', 'window-handle-2', 'window-handle-3']
-        break;
+        break
     case `/wd/hub/session/${sessionId}/url`:
         value = 'https://webdriver.io/?foo=bar'
-        break;
+        break
     case `/wd/hub/session/${sessionId}/title`:
         value = 'WebdriverIO - WebDriver bindings for Node.js'
-        break;
+        break
     }
 
     /**

--- a/packages/webdriverio/tests/commands/browser/newWindow.test.js
+++ b/packages/webdriverio/tests/commands/browser/newWindow.test.js
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment node
+ */
+
 import request from 'request'
 import { remote } from '../../../src'
 
@@ -11,6 +15,10 @@ describe('newWindow', () => {
                 browserName: 'foobar'
             }
         })
+
+        global.window = {
+            open: jest.fn()
+        }
     })
 
     it('should allow to create a new window handle', async () => {
@@ -40,5 +48,9 @@ describe('newWindow', () => {
         } catch (e) {
             expect(e.message).toContain('not supported on mobile')
         }
+    })
+
+    afterEach(() => {
+        global.window.open.mockClear()
     })
 })

--- a/packages/webdriverio/tests/commands/element/getHTML.test.js
+++ b/packages/webdriverio/tests/commands/element/getHTML.test.js
@@ -1,0 +1,29 @@
+import request from 'request'
+import { remote } from '../../../src'
+
+describe('getHTML test', () => {
+    it('should allow get html of an element', async () => {
+        const browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foobar'
+            }
+        })
+        const elem = await browser.$('#foo')
+        elem.elementId = {
+            outerHTML: '<some>outer html</some>',
+            innerHTML: 'some inner html'
+        }
+
+        let result = await elem.getHTML()
+        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/execute/sync')
+        expect(result).toBe('<some>outer html</some>')
+
+        result = await elem.getHTML(false)
+        expect(result).toBe('some inner html')
+    })
+
+    afterEach(() => {
+        request.mockClear()
+    })
+})

--- a/packages/webdriverio/tests/commands/element/scrollIntoView.test.js
+++ b/packages/webdriverio/tests/commands/element/scrollIntoView.test.js
@@ -16,8 +16,10 @@ describe('scrollIntoView test', () => {
     })
 
     it('should allow to check if an element is enabled', async () => {
+        elem.elementId = { scrollIntoView: jest.fn() }
         await elem.scrollIntoView()
         expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/execute/sync')
+        expect(elem.elementId.scrollIntoView.mock.calls).toHaveLength(1)
     })
 
     afterEach(() => {


### PR DESCRIPTION
`getHTML` is a common command to get the current DOM structure of a certain element. Let's port this command over and instead of using selectorExecute (which won't be ported) pass in the element id into the execute command.