### PR TITLE
fix job and context name for jasmine tests

### DIFF
--- a/packages/wdio-sauce-service/src/sauce-launch-service.js
+++ b/packages/wdio-sauce-service/src/sauce-launch-service.js
@@ -3,6 +3,8 @@ import SauceConnectLauncher from 'sauce-connect-launcher'
 
 const jobDataProperties = ['name', 'tags', 'public', 'build', 'custom-data']
 
+const jasmineTopLevelSuite = 'Jasmine__TopLevel__Suite'
+
 export default class SauceService {
     /**
      * modify config and launch sauce connect
@@ -88,10 +90,12 @@ export default class SauceService {
          * This tweak allows us to set the real suite name for jasmine jobs.
          */
         if (this.suiteTitle === 'Jasmine__TopLevel__Suite') {
-            this.suiteTitle = test.fullName.slice(0, test.fullName.indexOf(test.name) - 1)
+            this.suiteTitle = test.fullName.slice(0, test.fullName.indexOf(test.title) - 1)
         }
 
-        global.browser.execute('sauce:context=' + test.parent + ' - ' + test.title)
+        const context = test.parent === jasmineTopLevelSuite ? test.fullName : test.parent + ' - ' + test.title
+
+        global.browser.execute('sauce:context=' + context)
     }
 
     afterSuite (suite) {

--- a/packages/wdio-sauce-service/tests/sauce-launch-service.test.js
+++ b/packages/wdio-sauce-service/tests/sauce-launch-service.test.js
@@ -117,7 +117,7 @@ describe('wdio-sauce-service', () => {
         expect(sauceService.suiteTitle).toEqual('Test suite')
     })
 
-    it('beforeTest: execute called', () => {
+    it('beforeTest: execute called: suite is Jasmine__TopLevel__Suite', () => {
         const test = {
             name: 'Test name',
             fullName: 'Test #1',
@@ -131,6 +131,22 @@ describe('wdio-sauce-service', () => {
 
         expect(execute).toBeCalledWith('sauce:context=Test parent - Test title')
         expect(sauceService.suiteTitle).toEqual('Test ')
+    })
+
+    it('beforeTest: execute called: parent is Jasmine__TopLevel__Suite', () => {
+        const test = {
+            name: undefined,            
+            fullName: 'Test #1',
+            title: 'Test title',
+            parent: 'Jasmine__TopLevel__Suite'
+        }
+        sauceService.sauceUser = 'user'
+        sauceService.sauceKey = 'secret'
+        sauceService.suiteTitle = 'Test suite'
+        sauceService.beforeTest(test)
+
+        expect(execute).toBeCalledWith('sauce:context=Test #1')
+        expect(sauceService.suiteTitle).toEqual('Test suite')
     })
 
     it('afterSuite: no errors', () => {


### PR DESCRIPTION
## Proposed changes

When running tests in SauceLabs, a lot of the test contexts included Jasmine__TopLevel__Suite in the name. This PR removes that value from the context name.

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/v5/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
