### PR TITLE
wdio 5 could exit with error code, if no files found?

### DIFF
--- a/packages/wdio-cli/src/interface.js
+++ b/packages/wdio-cli/src/interface.js
@@ -134,7 +134,7 @@ export default class WDIOCLInterface extends EventEmitter {
             'Test Suites:\t', chalk.green(this.result.passed, 'passed') + ', ' +
             (this.result.failed ? chalk.red(this.result.failed, 'failed') + ', ' : '') +
             this.specs.length, 'total',
-            `(${Math.round((this.result.finished / this.specs.length) * 100)}% completed)`
+            `(${this.specs.length ? Math.round((this.result.finished / this.specs.length) * 100) : 0}% completed)`
         )
 
         this.updateClock()

--- a/packages/wdio-cli/src/launcher.js
+++ b/packages/wdio-cli/src/launcher.js
@@ -103,6 +103,15 @@ class Launcher {
             this.resolve = resolve
 
             /**
+             * fail if no specs were found or specified
+             */
+            if (Object.values(this.schedule).reduce((specCnt, schedule) => specCnt + schedule.specs.length, 0) === 0) {
+                log.error('No specs found to run, exiting with failure')
+                this.interface.updateView()
+                return resolve(1)
+            }
+
+            /**
              * return immediately if no spec was run
              */
             if (this.runSpecs()) {


### PR DESCRIPTION
_From @kajmagnus on January 16, 2018 8:15_

## The problem

wdio exits with status code 0 = all fine, if no files found. But most likely this means the user typed a typo or the wrong file name — because one wouldn't start wdio at all, if one didn't intend to run any tests?

The result is that a few times, I've started wdio as part of an automatic script, and incorrectly believed all tests were OK, although in fact some of the tests were never run.

Maybe change this, in upcoming Webdriver.io version 5? So no-files-found = error exit code?

(I asked about this in the Gitter chat, result: one person agreed that it'd be good with an error exit code, like 1; no other person replied)

## Environment

* WebdriverIO version: `wdio -v` says v4.9.11
* Node.js version: v7.10.1
* [Standalone mode or wdio testrunner](http://webdriver.io/guide/getstarted/modes.html): `wdio`
* if wdio testrunner, running synchronous or asynchronous tests: Synchronous
* Additional wdio packages used (if applicable): wdio-mocha-framework


## Code To Reproduce Issue [ Good To Have ]

Here you can see that wdio exits with code 0: (apparently there're two different ways to trigger exit code 0? 1) exact file name that isn't found, and 2) a pattern that matches nothing)

```
09:12:40 39 ~/dev/ed/ed-server[master*]$ cat no-files-found-exact.conf.js
"use strict";
var api = {
	config: {
    specs: ['no-files-found.js'],
    exclude: [],
    capabilities: [{
      browserName: 'chrome'
    }]
  }
};
module.exports = api;
09:12:48 40 ~/dev/ed/ed-server[master*]$ ./node_modules/.bin/wdio no-files-found-exact.conf.js

pattern no-files-found.js did not match any file

09:12:58 41 ~/dev/ed/ed-server[master*]$ echo $?
0

09:13:15 42 ~/dev/ed/ed-server[master*]$ cat no-files-found-pattern.conf.js
"use strict";
var api = {
	config: {
    specs: ['*no-files-found-pattern*.js'],
    exclude: [],
    capabilities: [{
      browserName: 'chrome'
    }]
  }
};
module.exports = api;

09:13:22 43 ~/dev/ed/ed-server[master*]$ ./node_modules/.bin/wdio no-files-found-pattern.conf.js
0 passing (1.60s)

09:13:32 44 ~/dev/ed/ed-server[master*]$ echo $?
0
```


_Copied from original issue: webdriverio/webdriverio#2547_