### PR TITLE
Spec and suite command line args as arrays

### DIFF
--- a/packages/wdio-config/src/lib/ConfigParser.js
+++ b/packages/wdio-config/src/lib/ConfigParser.js
@@ -91,7 +91,7 @@ export default class ConfigParser {
             const allSpecs = ConfigParser.getFilePaths(this._config.specs)
 
             spec.forEach((spec_file) => {
-                if (fs.existsSync(spec_file) && fs.lstatSync(spec).isFile()) {
+                if (fs.existsSync(spec_file) && fs.lstatSync(spec_file).isFile()) {
                     specs.add(path.resolve(process.cwd(), spec_file))
                 }
                 else {

--- a/packages/wdio-config/src/lib/ConfigParser.js
+++ b/packages/wdio-config/src/lib/ConfigParser.js
@@ -68,7 +68,7 @@ export default class ConfigParser {
      */
     merge (object = {}) {
         this._config = merge(this._config, object, MERGE_OPTIONS)
-        let spec = object.spec ? object.spec : []
+        let spec = Array.isArray(object.spec) ? object.spec : []
 
         /**
          * overwrite config specs that got piped into the wdio command
@@ -91,7 +91,7 @@ export default class ConfigParser {
             const allSpecs = ConfigParser.getFilePaths(this._config.specs)
 
             spec.forEach((spec_file) => {
-                if (fs.existsSync(spec_file)) {
+                if (fs.existsSync(spec_file) && fs.lstatSync(spec).isFile()) {
                     specs.add(path.resolve(process.cwd(), spec_file))
                 }
                 else {
@@ -152,9 +152,9 @@ export default class ConfigParser {
      */
     getSpecs (capSpecs, capExclude) {
         let specs = ConfigParser.getFilePaths(this._config.specs)
-        let spec  = this._config.spec ? this._config.spec : []
+        let spec  = Array.isArray(this._config.spec) ? this._config.spec : []
         let exclude = ConfigParser.getFilePaths(this._config.exclude)
-        let suites = this._config.suite ? this._config.suite : []
+        let suites = Array.isArray(this._config.suite) ? this._config.suite : []
 
         /**
          * check if user has specified a specific suites to run

--- a/packages/wdio-config/tests/configparser.test.js
+++ b/packages/wdio-config/tests/configparser.test.js
@@ -77,7 +77,7 @@ describe('ConfigParser', () => {
         it('should throw if specified spec file does not exist', () => {
             const configParser = new ConfigParser()
             configParser.addConfigFile(FIXTURES_CONF)
-            expect(() => configParser.merge({ spec: path.resolve(__dirname, 'foobar.js') })).toThrow()
+            expect(() => configParser.merge({ spec: [path.resolve(__dirname, 'foobar.js')] })).toThrow()
         })
 
         it('should allow to specify multiple suites', () => {

--- a/packages/wdio-config/tests/configparser.test.js
+++ b/packages/wdio-config/tests/configparser.test.js
@@ -37,7 +37,7 @@ describe('ConfigParser', () => {
         it('should allow specifying a spec file', () => {
             const configParser = new ConfigParser()
             configParser.addConfigFile(FIXTURES_CONF)
-            configParser.merge({ spec: INDEX_PATH })
+            configParser.merge({ spec: [INDEX_PATH] })
 
             const specs = configParser.getSpecs()
             expect(specs).toHaveLength(1)
@@ -47,12 +47,31 @@ describe('ConfigParser', () => {
         it('should allow specifying mutliple single spec file', () => {
             const configParser = new ConfigParser()
             configParser.addConfigFile(FIXTURES_CONF)
-            configParser.merge({ spec: `${INDEX_PATH},${FIXTURES_CONF}` })
+            configParser.merge({ spec : [INDEX_PATH, FIXTURES_CONF]})
 
             const specs = configParser.getSpecs()
             expect(specs).toHaveLength(2)
             expect(specs).toContain(INDEX_PATH)
             expect(specs).toContain(FIXTURES_CONF)
+        })
+
+        it('should allow to specify partial matching spec file', () => {
+            const configParser = new ConfigParser()
+            configParser.addConfigFile(FIXTURES_CONF)
+            configParser.merge({ spec : ['Plugin']})
+
+            const specs = configParser.getSpecs()
+            expect(specs).toContain(path.join(__dirname, 'initialisePlugin.test.js'))
+        })
+
+        it('should exclude duplicate spec files', () => {
+            const configParser = new ConfigParser()
+            configParser.addConfigFile(FIXTURES_CONF)
+            configParser.merge({ spec : [INDEX_PATH, INDEX_PATH]})
+
+            const specs = configParser.getSpecs()
+            expect(specs).toHaveLength(1)
+            expect(specs).toContain(INDEX_PATH)
         })
 
         it('should throw if specified spec file does not exist', () => {
@@ -64,7 +83,7 @@ describe('ConfigParser', () => {
         it('should allow to specify multiple suites', () => {
             const configParser = new ConfigParser()
             configParser.addConfigFile(FIXTURES_CONF)
-            configParser.merge({ suite: 'unit,functional,mobile' })
+            configParser.merge({ suite: ['unit', 'functional', 'mobile']})
 
             const specs = configParser.getSpecs()
             expect(specs).toContain(__filename)
@@ -76,21 +95,21 @@ describe('ConfigParser', () => {
         it('should throw when suite is not defined', () => {
             const configParser = new ConfigParser()
             configParser.addConfigFile(FIXTURES_CONF)
-            configParser.merge({ suite: 'blabla' })
+            configParser.merge({ suite: ['blabla'] })
             expect(() => configParser.getSpecs()).toThrow(/The suite\(s\) "blabla" you specified don't exist/)
         })
 
         it('should throw when multiple suites are not defined', () => {
             const configParser = new ConfigParser()
             configParser.addConfigFile(FIXTURES_CONF)
-            configParser.merge({ suite: 'blabla,lala' })
+            configParser.merge({ suite: ['blabla', 'lala'] })
             expect(() => configParser.getSpecs()).toThrow(/The suite\(s\) "blabla", "lala" you specified don't exist/)
         })
 
         it('should allow to specify a single suite', () => {
             const configParser = new ConfigParser()
             configParser.addConfigFile(FIXTURES_CONF)
-            configParser.merge({ suite: 'mobile' })
+            configParser.merge({ suite: ['mobile'] })
 
             let specs = configParser.getSpecs()
             expect(specs).toHaveLength(1)
@@ -188,7 +207,7 @@ describe('ConfigParser', () => {
         it('should include spec when specifying a suite', () => {
             const configParser = new ConfigParser()
             configParser.addConfigFile(FIXTURES_CONF)
-            configParser.merge({ suite: 'mobile', spec: INDEX_PATH })
+            configParser.merge({ suite: ['mobile'], spec: [INDEX_PATH] })
 
             let specs = configParser.getSpecs()
             expect(specs).toHaveLength(2)


### PR DESCRIPTION
## Proposed changes

This fixes #90 and implements suite and spec command line arguments as arrays.

Tests can now be ran like this:

```./node_modules/.bin/wdio wdio.conf.js --spec ./test/foo.test.js ./test/bar.test.js```
```./node_modules/.bin/wdio wdio.conf.js --suite Foo Bar```

In V4 they would have been ran like this:

```./node_modules/.bin/wdio wdio.conf.js --spec ./test/foo.test.js,./test/bar.test.js```
```./node_modules/.bin/wdio wdio.conf.js --suite Foo,Bar```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/v5/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

### Reviewers: @webdriverio/technical-committee
