### PR TITLE
Add setValue command

### DIFF
--- a/packages/webdriverio/src/commands/element/setValue.js
+++ b/packages/webdriverio/src/commands/element/setValue.js
@@ -1,0 +1,34 @@
+/**
+ *
+ * Send a sequence of key strokes to an element (clears value before). If the element
+ * doesn't need to be cleared first then use addValue. You can also use
+ * unicode characters like Left arrow or Back space. WebdriverIO will take care of
+ * translating them into unicode characters. You’ll find all supported characters
+ * [here](https://w3c.github.io/webdriver/webdriver-spec.html#keyboard-actions).
+ * To do that, the value has to correspond to a key from the table.
+ *
+ * <example>
+    :setValue.js
+    it('should set value for a certain element', () => {
+        const input = $('.input');
+        input.setValue('test123');
+
+        // Same as
+        browser.setValue('.input', 'test123');
+        console.log(input.getValue()); // outputs: 'test123'
+    });
+ * </example>
+ *
+ * @alias browser.setValue
+ * @param {String} selector   Input element
+ * @param {*}      values    Value to be added
+ * @uses protocol/elements, protocol/elementIdClear, protocol/elementIdValue
+ * @type action
+ *
+ */
+
+export default async function setValue (value) {
+    await this.clearValue()
+
+    return this.addValue(value)
+}

--- a/packages/webdriverio/tests/commands/element/setValue.test.js
+++ b/packages/webdriverio/tests/commands/element/setValue.test.js
@@ -1,0 +1,20 @@
+import request from 'request'
+import { remote } from '../../../src'
+
+describe('setValue', () => {
+    test('should set the value clearning the element first', async () => {
+        const browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foobar'
+            }
+        })
+
+        const elem = await browser.$('#foo')
+
+        await elem.setValue('foobar')
+        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/clear')
+        expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/value')
+        expect(request.mock.calls[3][0].body.text).toBe('foobar')
+    })
+})


### PR DESCRIPTION
## Proposed changes

Adds the setValue command like it is in v4.

I've found ourselves having to clear a lot of inputs before adding values so I think this would be good to keep in v5.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/v5/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

### Reviewers: @webdriverio/technical-committee
