### PR TITLE
waitForVisible fix when element doesn't already exist

### DIFF
--- a/packages/webdriverio/src/commands/element/waitForVisible.js
+++ b/packages/webdriverio/src/commands/element/waitForVisible.js
@@ -27,15 +27,15 @@
  *
  */
 
-export default function waitForVisible (ms, reverse = false) {
+export default async function waitForVisible (ms, reverse = false) {
     /**
      * if element wasn't found in the first place wait for its existance first
      */
     if (!this.elementId && !reverse) {
-        return this.waitForExist(ms).then(() => this.waitForVisible(ms))
+        await this.waitForExist(ms)
     }
 
-    /*!
+    /*
      * ensure that ms is set properly
      */
     if (typeof ms !== 'number') {
@@ -45,8 +45,9 @@ export default function waitForVisible (ms, reverse = false) {
     const isReversed = reverse ? '' : 'not'
     const errorMsg = `element ("${this.selector}") still ${isReversed} visible after ${ms}ms`
 
-    return this.waitUntil(function async () {
-        return this.isElementDisplayed(this.elementId)
-            .then((isVisible) => isVisible !== reverse)
+    return this.waitUntil(async () => {
+        const isVisible = await this.isElementDisplayed(this.elementId)
+
+        return isVisible !== reverse
     }, ms, errorMsg)
 }

--- a/packages/webdriverio/tests/commands/element/waitForVisible.test.js
+++ b/packages/webdriverio/tests/commands/element/waitForVisible.test.js
@@ -71,7 +71,7 @@ describe('waitUntil', () => {
         expect(request.mock.calls[5][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/displayed')
     })
 
-    test('aaaaashould call isElementDisplayed and return false', async () => {
+    test('should call isElementDisplayed and return true', async () => {
         const tmpElem = await browser.$(`#foo`)
         const elem = {
             selector : '#foo',
@@ -85,13 +85,6 @@ describe('waitUntil', () => {
 
         const result = await elem.waitForVisible(duration)
         expect(result).toBe(true)
-        /*
-        try {
-            await elem.waitForVisible(duration)
-        } catch (e) {
-            expect(e.message).toBe(`element ("#foo") still not visible after ${duration}ms`)
-        }
-        */
     })
 
     test('should call isElementDisplayed and return false', async () => {

--- a/packages/webdriverio/tests/commands/element/waitForVisible.test.js
+++ b/packages/webdriverio/tests/commands/element/waitForVisible.test.js
@@ -1,0 +1,134 @@
+import request from 'request'
+import { remote } from '../../../src'
+
+describe('waitUntil', () => {
+    const duration = 1000
+    let browser
+
+    beforeAll(async () => {
+        request.mockClear()
+
+        browser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                browserName: 'foobar'
+            }
+        })
+    })
+
+    test('should wait for the element to exist', async () => {
+        const tmpElem = await browser.$(`#foo`)
+        const elem = {
+            waitForVisible : tmpElem.waitForVisible,
+            waitForExist : jest.fn(),
+            elementId : null,
+            waitUntil : jest.fn(),
+            isElementDisplayed : jest.fn(() => Promise.resolve())
+        }
+
+        await elem.waitForVisible(duration)
+        expect(elem.waitForExist).toBeCalled()
+    })
+
+    test('element should already exist on the page', async () => {
+        const tmpElem = await browser.$(`#foo`)
+        const elem = {
+            waitForVisible : tmpElem.waitForVisible,
+            waitForExist : jest.fn(),
+            elementId : 123,
+            waitUntil : jest.fn(),
+            isElementDisplayed : jest.fn(() => Promise.resolve())
+        }
+
+        await elem.waitForVisible(duration)
+        expect(elem.waitForExist).not.toBeCalled()
+    })
+
+    test('should call waitUntil', async () => {
+        const cb = jest.fn()
+        const tmpElem = await browser.$(`#foo`)
+        const elem = {
+            selector : '#foo',
+            waitForVisible : tmpElem.waitForVisible,
+            waitForExist : jest.fn(),
+            elementId : 123,
+            waitUntil : jest.fn(((cb))),
+            isElementDisplayed : jest.fn(() => Promise.resolve())
+        }
+
+        await elem.waitForVisible(duration)
+
+        expect(cb).toBeCalled()
+        expect(elem.waitUntil.mock.calls[0][1]).toBe(duration)
+        expect(elem.waitUntil.mock.calls[0][2]).toBe(`element ("#foo") still not visible after ${duration}ms`)
+    })
+
+    test('should call isElementDisplayed and return true', async () => {
+        const elem = await browser.$(`#foo`)
+        const result = await elem.waitForVisible(duration)
+
+        expect(result).toBe(true)
+        expect(request.mock.calls[5][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/displayed')
+    })
+
+    test('aaaaashould call isElementDisplayed and return false', async () => {
+        const tmpElem = await browser.$(`#foo`)
+        const elem = {
+            selector : '#foo',
+            waitForVisible : tmpElem.waitForVisible,
+            waitForExist : jest.fn(),
+            elementId : 123,
+            waitUntil : tmpElem.waitUntil,
+            isElementDisplayed : jest.fn(() => true),
+            options : { waitforTimeout : 500 },
+        }
+
+        const result = await elem.waitForVisible(duration)
+        expect(result).toBe(true)
+        /*
+        try {
+            await elem.waitForVisible(duration)
+        } catch (e) {
+            expect(e.message).toBe(`element ("#foo") still not visible after ${duration}ms`)
+        }
+        */
+    })
+
+    test('should call isElementDisplayed and return false', async () => {
+        const tmpElem = await browser.$(`#foo`)
+        const elem = {
+            selector : '#foo',
+            waitForVisible : tmpElem.waitForVisible,
+            waitForExist : jest.fn(),
+            elementId : 123,
+            waitUntil : tmpElem.waitUntil,
+            isElementDisplayed : jest.fn(() => false),
+            options : { waitforTimeout : 500 },
+        }
+
+        try {
+            await elem.waitForVisible(duration)
+        } catch (e) {
+            expect(e.message).toBe(`element ("#foo") still not visible after ${duration}ms`)
+        }
+    })
+
+    test('should do reverse', async () => {
+        const cb = jest.fn()
+        const tmpElem = await browser.$(`#foo`)
+        const elem = {
+            selector : '#foo',
+            waitForVisible : tmpElem.waitForVisible,
+            waitForExist : jest.fn(),
+            elementId : 123,
+            waitUntil : jest.fn(((cb))),
+            isElementDisplayed : jest.fn(() => Promise.resolve()),
+            options : { waitforTimeout : 500 },
+        }
+
+        await elem.waitForVisible(null, true)
+
+        expect(elem.waitUntil.mock.calls[0][1]).toBe(elem.options.waitforTimeout)
+        expect(elem.waitUntil.mock.calls[0][2]).toBe(`element ("#foo") still ${``} visible after ${elem.options.waitforTimeout}ms`)
+    })
+})


### PR DESCRIPTION
## Proposed changes

When calling waitForVisible() and the element doesn't already exist on the page it gets into a recursive loop calling itself resulting in a never ending call.

Changing it to not call itself and just wait for waitForExist to complete.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/v5/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Code to reproduce

```
<html>
        <script>
                setTimeout(() => {
                        const elem = document.createElement(`div`);
                        elem.textContent = `tests`;
                        elem.classList.add(`foobar`);
                        document.querySelector(`.container`).append(elem);
                }, 10000);
        </script>
        <body>
                <div class="container"></div>
        </body>
</html>
```

```
describe(`Test`, () => {
	it(`should...`, () => {
		browser.url(`/local/file`);
		$(`.foobar`).waitForVisible()
	});
});
```

### Reviewers: @webdriverio/technical-committee
