### PR TITLE
webdriverio: Add waitForEnabled command

### DIFF
--- a/packages/webdriverio/src/commands/element/waitForEnabled.js
+++ b/packages/webdriverio/src/commands/element/waitForEnabled.js
@@ -1,0 +1,60 @@
+/**
+ *
+ * Wait for an element (selected by css selector) for the provided amount of
+ * milliseconds to be (dis/en)abled. If multiple elements get queried by given
+ * selector, it returns true (or false if reverse flag is set) if at least one
+ * element is (dis/en)abled.
+ *
+ * <example>
+    :index.html
+    <input type="text" id="username" value="foobar" disabled="disabled"></input>
+    <script type="text/javascript">
+        setTimeout(function () {
+            document.getElementById('username').disabled = false
+        }, 2000);
+    </script>
+    :waitForEnabledExample.js
+    it('should detect when element is enabled', () => {
+        browser.waitForEnabled('#username', 3000);
+
+        // Same as
+        elem = $('#username');
+        elem.waitForEnabled(3000)
+    });
+
+    it('should detect when element is disabled', () => {
+        browser.waitForEnabled('#username', 3000, true);
+
+        // Same as
+        elem = $('#username');
+        elem.waitForEnabled(3000, true)
+    });
+ * </example>
+ *
+ * @alias browser.waitForEnabled
+ * @param {Number=}  ms       time in ms (default: 500)
+ * @param {Boolean=} reverse  if true it waits for the opposite (default: false)
+ * @uses utility/waitUntil, state/isEnabled
+ * @type utility
+ *
+ */
+
+export default async function waitForEnabled(ms, reverse = false) {
+    // If the element doesn't already exist, wait for it to exist
+    if (!this.elementId && !reverse) {
+        await this.waitForExist(ms)
+    }
+
+    if (typeof ms !== 'number') {
+        ms = this.options.waitforTimeout
+    }
+
+    const isReversed = reverse ? '' : 'not'
+    const errorMessage = `element ("${this.selector}") still ${isReversed} enabled after ${ms}ms`
+
+    return this.waitUntil(async () => {
+        const isEnabled = await this.isEnabled()
+
+        return isEnabled !== reverse
+    }, ms, errorMessage)
+}

--- a/packages/webdriverio/src/middlewares.js
+++ b/packages/webdriverio/src/middlewares.js
@@ -21,7 +21,7 @@ export const elementErrorHandler = (fn) => (commandName, commandFn) => {
          *  - elementId couldn't be fetched in the first place
          *  - command is not explicit wait command for existance or displayedness
          */
-        if (!this.elementId && !commandName.match(/(wait(Until|ForVisible|ForExist)|isExisting)/)) {
+        if (!this.elementId && !commandName.match(/(wait(Until|ForVisible|ForExist|ForEnabled)|isExisting)/)) {
             log.debug(
                 `command ${commandName} was called on an element ("${this.selector}") ` +
                 `that wasn't found, waiting for it...`

--- a/packages/webdriverio/tests/commands/element/waitForEnabled.test.js
+++ b/packages/webdriverio/tests/commands/element/waitForEnabled.test.js
@@ -1,7 +1,7 @@
 import request from 'request'
 import { remote } from '../../../src'
 
-describe('waitForVisible', () => {
+describe('waitForEnabled', () => {
     const duration = 1000
     let browser
 
@@ -19,28 +19,28 @@ describe('waitForVisible', () => {
     test('should wait for the element to exist', async () => {
         const tmpElem = await browser.$(`#foo`)
         const elem = {
-            waitForVisible : tmpElem.waitForVisible,
+            waitForEnabled : tmpElem.waitForEnabled,
             waitForExist : jest.fn(),
             elementId : null,
             waitUntil : jest.fn(),
-            isElementDisplayed : jest.fn(() => Promise.resolve())
+            isEnabled : jest.fn(() => Promise.resolve())
         }
 
-        await elem.waitForVisible(duration)
+        await elem.waitForEnabled(duration)
         expect(elem.waitForExist).toBeCalled()
     })
 
     test('element should already exist on the page', async () => {
         const tmpElem = await browser.$(`#foo`)
         const elem = {
-            waitForVisible : tmpElem.waitForVisible,
+            waitForEnabled : tmpElem.waitForEnabled,
             waitForExist : jest.fn(),
             elementId : 123,
             waitUntil : jest.fn(),
-            isElementDisplayed : jest.fn(() => Promise.resolve())
+            isEnabled : jest.fn(() => Promise.resolve())
         }
 
-        await elem.waitForVisible(duration)
+        await elem.waitForEnabled(duration)
         expect(elem.waitForExist).not.toBeCalled()
     })
 
@@ -49,60 +49,52 @@ describe('waitForVisible', () => {
         const tmpElem = await browser.$(`#foo`)
         const elem = {
             selector : '#foo',
-            waitForVisible : tmpElem.waitForVisible,
+            waitForEnabled : tmpElem.waitForEnabled,
             waitForExist : jest.fn(),
             elementId : 123,
             waitUntil : jest.fn(((cb))),
-            isElementDisplayed : jest.fn(() => Promise.resolve())
+            isEnabled : jest.fn(() => Promise.resolve())
         }
 
-        await elem.waitForVisible(duration)
+        await elem.waitForEnabled(duration)
 
         expect(cb).toBeCalled()
         expect(elem.waitUntil.mock.calls[0][1]).toBe(duration)
-        expect(elem.waitUntil.mock.calls[0][2]).toBe(`element ("#foo") still not visible after ${duration}ms`)
+        expect(elem.waitUntil.mock.calls[0][2]).toBe(`element ("#foo") still not enabled after ${duration}ms`)
     })
 
-    test('should call isElementDisplayed and return true', async () => {
-        const elem = await browser.$(`#foo`)
-        const result = await elem.waitForVisible(duration)
-
-        expect(result).toBe(true)
-        expect(request.mock.calls[5][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/displayed')
-    })
-
-    test('should call isElementDisplayed and return true', async () => {
+    test('should call isEnabled and return true', async () => {
         const tmpElem = await browser.$(`#foo`)
         const elem = {
             selector : '#foo',
-            waitForVisible : tmpElem.waitForVisible,
+            waitForEnabled : tmpElem.waitForEnabled,
             waitForExist : jest.fn(),
             elementId : 123,
             waitUntil : tmpElem.waitUntil,
-            isElementDisplayed : jest.fn(() => true),
+            isEnabled : jest.fn(() => true),
             options : { waitforTimeout : 500 },
         }
 
-        const result = await elem.waitForVisible(duration)
+        const result = await elem.waitForEnabled(duration)
         expect(result).toBe(true)
     })
 
-    test('should call isElementDisplayed and return false', async () => {
+    test('should call isEnabled and return false', async () => {
         const tmpElem = await browser.$(`#foo`)
         const elem = {
             selector : '#foo',
-            waitForVisible : tmpElem.waitForVisible,
+            waitForEnabled : tmpElem.waitForEnabled,
             waitForExist : jest.fn(),
             elementId : 123,
             waitUntil : tmpElem.waitUntil,
-            isElementDisplayed : jest.fn(() => false),
+            isEnabled : jest.fn(() => false),
             options : { waitforTimeout : 500 },
         }
 
         try {
-            await elem.waitForVisible(duration)
+            await elem.waitForEnabled(duration)
         } catch (e) {
-            expect(e.message).toBe(`element ("#foo") still not visible after ${duration}ms`)
+            expect(e.message).toBe(`element ("#foo") still not enabled after ${duration}ms`)
         }
     })
 
@@ -111,17 +103,17 @@ describe('waitForVisible', () => {
         const tmpElem = await browser.$(`#foo`)
         const elem = {
             selector : '#foo',
-            waitForVisible : tmpElem.waitForVisible,
+            waitForEnabled : tmpElem.waitForEnabled,
             waitForExist : jest.fn(),
             elementId : 123,
             waitUntil : jest.fn(((cb))),
-            isElementDisplayed : jest.fn(() => Promise.resolve()),
+            isEnabled : jest.fn(() => Promise.resolve()),
             options : { waitforTimeout : 500 },
         }
 
-        await elem.waitForVisible(null, true)
+        await elem.waitForEnabled(null, true)
 
         expect(elem.waitUntil.mock.calls[0][1]).toBe(elem.options.waitforTimeout)
-        expect(elem.waitUntil.mock.calls[0][2]).toBe(`element ("#foo") still ${``} visible after ${elem.options.waitforTimeout}ms`)
+        expect(elem.waitUntil.mock.calls[0][2]).toBe(`element ("#foo") still ${``} enabled after ${elem.options.waitforTimeout}ms`)
     })
 })


### PR DESCRIPTION
## Proposed changes

Add waitForEnabled command. Acts like the v4 command with the exception it will wait for the element to exist on the page if it's not already existing.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/v5/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

### Reviewers: @webdriverio/technical-committee
