### PR TITLE
Fix for checkUnicode not being called

### DIFF
--- a/packages/webdriverio/src/utils.js
+++ b/packages/webdriverio/src/utils.js
@@ -235,7 +235,7 @@ export function transformToCharString (value) {
 
     for (const val of value) {
         if (typeof val === 'string') {
-            ret.push(...val.split(''))
+            ret.push(...checkUnicode(val))
         } else if (typeof val === 'number') {
             const entry = `${val}`.split('')
             ret.push(...entry)

--- a/packages/webdriverio/tests/utils.test.js
+++ b/packages/webdriverio/tests/utils.test.js
@@ -464,7 +464,7 @@ describe('utils', () => {
             expect(result[0]).toEqual('\uE011')
         })
 
-        it('should return an arry without unicode', () => {
+        it('should return an array without unicode', () => {
             const result = checkUnicode('foo')
 
             expect(Array.isArray(result)).toBe(true)

--- a/packages/webdriverio/tests/utils.test.js
+++ b/packages/webdriverio/tests/utils.test.js
@@ -4,7 +4,8 @@ import {
     mobileDetector,
     getBrowserObject,
     transformToCharString,
-    parseCSS
+    parseCSS,
+    checkUnicode,
 } from '../src/utils'
 
 describe('utils', () => {
@@ -375,6 +376,13 @@ describe('utils', () => {
             expect(transformToCharString(['foo', undefined, { b: 1 }, null, 42, false])).toEqual(
                 ['f', 'o', 'o', '{', '"', 'b', '"', ':', '1', '}', '4', '2', 'f', 'a', 'l', 's', 'e'])
         })
+
+        it('should convert string to unicode', () => {
+            expect(transformToCharString('Enter')).toEqual(['\uE007'])
+            expect(transformToCharString('Back space')).toEqual(['\uE003'])
+            expect(transformToCharString('Backspace')).toEqual(['\uE003'])
+            expect(transformToCharString('Pageup')).toEqual(['\uE00E'])
+        })
     })
 
     describe('parseCSS', () => {
@@ -445,6 +453,24 @@ describe('utils', () => {
                     value: 42
                 }
             })
+        })
+    })
+
+    describe('checkUnicode', () => {
+        it('should return array with unicode', () => {
+            const result = checkUnicode('Home')
+
+            expect(Array.isArray(result)).toBe(true)
+            expect(result[0]).toEqual('\uE011')
+        })
+
+        it('should return an arry without unicode', () => {
+            const result = checkUnicode('foo')
+
+            expect(Array.isArray(result)).toBe(true)
+            expect(result[0]).toBe('f')
+            expect(result[1]).toBe('o')
+            expect(result[2]).toBe('o')
         })
     })
 })


### PR DESCRIPTION
## Proposed changes

The checkUnicode function was never being called resulting in things like `Enter` not being converted over to `\uE007`.

```
$('.foo').addValue('Enter') // This would not be converted over
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/v5/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

### Reviewers: @webdriverio/technical-committee
