### PR TITLE
webdriverio: selectByVisibleText with spaces

### DIFF
--- a/packages/webdriverio/src/commands/element/selectByVisibleText.js
+++ b/packages/webdriverio/src/commands/element/selectByVisibleText.js
@@ -44,7 +44,7 @@ export default async function selectByVisibleText (text) {
     const formatted = /"/.test(text)
         ? 'concat("' + text.trim().split('"').join('", \'"\', "') + '")'
         : `"${text.trim()}"`
-    const normalized = `[normalize-space(translate(., ' ', '')) = ${formatted}]`
+    const normalized = `[normalize-space(text()) = ${formatted}]`
     const optionElement = await this.findElementFromElement(this.elementId, 'xpath', `./option${normalized}|./optgroup/option${normalized}`)
 
     /**

--- a/packages/webdriverio/tests/commands/element/selectByVisibleText.test.js
+++ b/packages/webdriverio/tests/commands/element/selectByVisibleText.test.js
@@ -28,7 +28,19 @@ describe('selectByVisibleText test', () => {
 
         expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/element')
         expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/element')
-        expect(request.mock.calls[2][0].body.value).toBe(`./option[normalize-space(translate(., ' ', '')) = "someValue1"]|./optgroup/option[normalize-space(translate(., ' ', '')) = "someValue1"]`)
+        expect(request.mock.calls[2][0].body.value).toBe(`./option[normalize-space(text()) = "someValue1"]|./optgroup/option[normalize-space(text()) = "someValue1"]`)
+        expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-sub-elem-321/click')
+        expect(getElementFromResponseSpy).toBeCalledWith({
+            [ELEMENT_KEY]: 'some-sub-elem-321'
+        })
+    })
+
+    it('should select value by visible text with spaces', async () => {
+        await elem.selectByVisibleText('some Value1')
+
+        expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/element')
+        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/element')
+        expect(request.mock.calls[2][0].body.value).toBe(`./option[normalize-space(text()) = "some Value1"]|./optgroup/option[normalize-space(text()) = "some Value1"]`)
         expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-sub-elem-321/click')
         expect(getElementFromResponseSpy).toBeCalledWith({
             [ELEMENT_KEY]: 'some-sub-elem-321'
@@ -40,7 +52,19 @@ describe('selectByVisibleText test', () => {
 
         expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/element')
         expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/element')
-        expect(request.mock.calls[2][0].body.value).toBe(`./option[normalize-space(translate(., ' ', '')) = concat("", '"', "someValue1", '"', "", '"', "")]|./optgroup/option[normalize-space(translate(., ' ', '')) = concat("", '"', "someValue1", '"', "", '"', "")]`)
+        expect(request.mock.calls[2][0].body.value).toBe(`./option[normalize-space(text()) = concat("", '"', "someValue1", '"', "", '"', "")]|./optgroup/option[normalize-space(text()) = concat("", '"', "someValue1", '"', "", '"', "")]`)
+        expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-sub-elem-321/click')
+        expect(getElementFromResponseSpy).toBeCalledWith({
+            [ELEMENT_KEY]: 'some-sub-elem-321'
+        })
+    })
+
+    it('should convert number to string when selecting', async () => {
+        await elem.selectByVisibleText(123)
+
+        expect(request.mock.calls[1][0].uri.path).toBe('/wd/hub/session/foobar-123/element')
+        expect(request.mock.calls[2][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-elem-123/element')
+        expect(request.mock.calls[2][0].body.value).toBe(`./option[normalize-space(text()) = "123"]|./optgroup/option[normalize-space(text()) = "123"]`)
         expect(request.mock.calls[3][0].uri.path).toBe('/wd/hub/session/foobar-123/element/some-sub-elem-321/click')
         expect(getElementFromResponseSpy).toBeCalledWith({
             [ELEMENT_KEY]: 'some-sub-elem-321'


### PR DESCRIPTION
## Proposed changes

When trying to select text that has spaces in the middle it is failing because xpath can't find anything. e.g. ```Foo Baz```

```
Malformed type for "elementId" parameter of command elementClick
Expected: string
Actual: object

For more info see https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidelementidclick
```

I'm not very familiar with xpath so if I'm doing something wrong let me know. Not exactly sure why it's not working since it's using the same xpath selector in v4.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/v5/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Code to reproduce

```
<html>
  <body>
    <select>
      <option value=""></option>
      <option value="foo">Foo</option>
      <option value="bar">Bar</option>
      <option value="foobaz">Foo Baz</option>
    </select>
  </body>
</html>
```

```
describe('Test', () => {
  it('should select with spaces', () => {
    $('select').selectByVisibleText('Foo Baz')
  })
})
```

### Reviewers: @webdriverio/technical-committee
