### PR TITLE
Wdio-runner: Fix loading reporter's options

### DIFF
--- a/packages/wdio-runner/src/reporter.js
+++ b/packages/wdio-runner/src/reporter.js
@@ -60,6 +60,13 @@ export default class BaseReporter {
         }
 
         /**
+         * check if reporter has reporterOptions
+         */
+        if (this.config.reporterOptions && this.config.reporterOptions[reporter]) {
+            options = Object.assign(options, this.config.reporterOptions[reporter])
+        }
+
+        /**
          * check if reporter has custom options
          */
         if (Array.isArray(reporter)) {

--- a/packages/wdio-runner/tests/reporter.test.js
+++ b/packages/wdio-runner/tests/reporter.test.js
@@ -44,6 +44,39 @@ describe('BaseReporter', () => {
         expect(reporter.getLogFile('foobar')).toBe(undefined)
     })
 
+    test('should load custom options', () => {
+        const reporter = new BaseReporter({
+            reporterOptions:{},
+            reporters: [
+                ['dot', { foo: 'bar' }]
+            ]
+        }, '0-0')
+
+        expect(reporter.reporters[0].options.foo).toBe('bar')
+    })
+
+    test('should load options from reporterOptions', () => {
+        const reporter = new BaseReporter({
+            reporterOptions:{dot: { foo: 'bar' }},
+            reporters: [
+                ['dot']
+            ]
+        }, '0-0')
+
+        expect(reporter.reporters[0].options.foo).toBe('bar')
+    })
+
+    test('should override reporterOptions by custom options', () => {
+        const reporter = new BaseReporter({
+            reporterOptions:{dot: { foo: 'bar' }},
+            reporters: [
+                ['dot', { foo: 'baz' }]
+            ]
+        }, '0-0')
+
+        expect(reporter.reporters[0].options.foo).toBe('baz')
+    })
+
     it('should emit events to all reporters', () => {
         const reporter = new BaseReporter({
             logDir: '/foo/bar',


### PR DESCRIPTION
## Proposed changes
Allow to load reporter options form `config.reporterOptions` and override them by reporter's custom options

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/v5/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

### Reviewers: @webdriverio/technical-committee
