### PR TITLE
keys.js: Use unicode segmentation instead of character segmentation

### DIFF
--- a/packages/webdriverio/package.json
+++ b/packages/webdriverio/package.json
@@ -54,6 +54,7 @@
   },
   "dependencies": {
     "css-value": "^0.0.1",
+    "grapheme-splitter": "^1.0.2",
     "lodash.zip": "^4.2.0",
     "rgb2hex": "^0.1.0",
     "wdio-config": "^5.0.0-alpha.14",

--- a/packages/webdriverio/src/utils.js
+++ b/packages/webdriverio/src/utils.js
@@ -2,6 +2,7 @@ import fs from 'fs'
 import path from 'path'
 import cssValue from 'css-value'
 import rgb2hex from 'rgb2hex'
+import GraphemeSplitter from 'grapheme-splitter'
 
 import { ELEMENT_KEY, W3C_SELECTOR_STRATEGIES, UNICODE_CHARACTERS } from './constants'
 
@@ -326,5 +327,5 @@ export function parseCSS (cssPropertyValue, cssProperty) {
  * @return {Array}         set of characters or unicode symbols
  */
 export function checkUnicode (value) {
-    return UNICODE_CHARACTERS.hasOwnProperty(value) ? [UNICODE_CHARACTERS[value]] : value.split('')
+    return UNICODE_CHARACTERS.hasOwnProperty(value) ? [UNICODE_CHARACTERS[value]] : new GraphemeSplitter().splitGraphemes(value)
 }


### PR DESCRIPTION
Port of https://github.com/webdriverio/webdriverio/pull/2844

## Proposed changes

Currently when using unicode characters like emojis that require more than one characters for representation in javascript strings are sent separately, leading them to not be rendered correctly. This patch proposes [segmentation of unicode text by visibility](http://unicode.org/reports/tr29/) using the grapheme-splitter library.


## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/v5/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/technical-committee
